### PR TITLE
Multiple regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ Highlight text using the `-r` (or `--regex`) option. For example
 
     echo "A Foo and a Bar" | txts -r "Foo|Bar"
 
+will color both Foo and Bar in red. If you use the `-r` option
+multiple times, each of the specified regexps will have a different
+color, as in:
+
+    echo "A Foo and a Bar" | txts -r Foo -r Bar
+
+You can also specify multiple regexps with the `-R` (or `--regex-rest`)
+option with the very same result:
+
+    echo "A Foo and a Bar" | txts -R Foo Bar
+
 `TxtStyle` does not apply styles if output is piped to another command.
 To force color if the output is piped, use `--color-always` option:
 

--- a/arg-test.sh
+++ b/arg-test.sh
@@ -24,6 +24,10 @@ assert_exit_code 0 "./txts -n java $test_log"
 # --regex
 assert_exit_code 0 "./txts --regex 'some pattern' $test_log"
 assert_exit_code 0 "./txts -r 'some pattern' $test_log"
+assert_exit_code 0 "./txts --regex 'some pattern' --regex 'another pattern' $test_log"
+assert_exit_code 0 "./txts -r 'some pattern' -r 'another pattern' $test_log"
+assert_exit_code 0 "./txts $test_log --regex-rest 'some pattern' 'another pattern' 'yet another pattern'"
+assert_exit_code 0 "./txts $test_log -R 'some pattern' 'another pattern' 'yet another pattern'"
 # --conf
 assert_exit_code 0 "./txts --conf txtstyle/testdata/test.txts.conf -n first $test_log"
 assert_exit_code 0 "./txts -c txtstyle/testdata/test.txts.conf -n first $test_log"

--- a/txts
+++ b/txts
@@ -20,6 +20,7 @@ import errno
 import os
 import sys
 import time
+import itertools
 
 from txtstyle.confparser import ConfParser, ConfParserException
 from txtstyle.palette import Palette
@@ -96,8 +97,8 @@ def parse_args():
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-p', '--palette', help='Print a palette of available styles.', action='store_true')
     group.add_argument('-n', '--name', nargs=1, help='Name of the style to apply.')
-    group.add_argument('-r', '--regex', nargs=1, help='Highlight text based on the given regular expression.')
-
+    group.add_argument('-r', '--regex', nargs=1, action='append', help='Highlight text based on the given regular expression.')
+    group.add_argument('-R', '--regex-rest', nargs='*', dest="regex", action="append", help='Highlight texts based on regexps given (consumed until the end of the commandline).')
     parser.add_argument('-c', '--conf', nargs=1, help='Path to a conf file. Default is: ~/.txt.conf')
     parser.add_argument('--color-always', help='Always use color. Similar to grep --color=always.', action='store_true')
 
@@ -132,6 +133,12 @@ def get_conf_path(args):
                 f.write(DEFAULT_CONF)
         return _USER_HOME_CONF_FILE
 
+def loop_default_colors():
+    while True:
+        for style in ['bold','underline']:
+            for col in ['red', 'green', 'blue', 'magenta', 'cyan', 'white']:
+                yield ( col, style )
+
 def main():
     args = parse_args()
     styles = []
@@ -148,9 +155,10 @@ def main():
         style_def_name = args.name[0]
         styles = get_styles(conf_parser, style_def_name)
     elif args.regex:
-        regex = args.regex[0]
-        transforms = ['red', 'bold']
-        styles = [RegexStyle(regex, transforms)]
+        rexps = list(itertools.chain.from_iterable(args.regex))
+        styles = [ RegexStyle(regex, style)
+                for regex, style in zip(rexps,
+                                    loop_default_colors()) ]
 
     txts = Txts(styles, args.filepath, args.color_always)
     txts.transform()


### PR DESCRIPTION
Added support for specifying multiple regexps on commandline, these are colored differently, the changes in README.md show the usage. I also added another option, -R, which consumes multiple regexps (until EOL or another option). The -R has however one setback; namely, if the filename is specified as well, it needs to come before the -R, otw it would be (logically) interpreted as regexp.